### PR TITLE
Fast random number generator

### DIFF
--- a/lockedrng.go
+++ b/lockedrng.go
@@ -1,0 +1,27 @@
+package slogsampling
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// lockedRNG is safe to be shared by multiple goroutines.
+type lockedRNG struct {
+	mu  sync.Mutex
+	rng *rand.Rand
+}
+
+// newLockedRNG returns a new lockedRNG seeded with the current time.
+func newLockedRNG() *lockedRNG {
+	return &lockedRNG{
+		sync.Mutex{},
+		rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+func (l *lockedRNG) Float64() float64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.rng.Float64()
+}

--- a/middleware_custom.go
+++ b/middleware_custom.go
@@ -2,8 +2,6 @@ package slogsampling
 
 import (
 	"context"
-	"math/rand"
-	"time"
 
 	"log/slog"
 
@@ -21,7 +19,7 @@ type CustomSamplingOption struct {
 
 // NewMiddleware returns a slog-multi middleware.
 func (o CustomSamplingOption) NewMiddleware() slogmulti.Middleware {
-	rand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	rand := newLockedRNG()
 
 	return slogmulti.NewInlineMiddleware(
 		func(ctx context.Context, level slog.Level, next func(context.Context, slog.Level) bool) bool {

--- a/middleware_threshold.go
+++ b/middleware_threshold.go
@@ -2,7 +2,6 @@ package slogsampling
 
 import (
 	"context"
-	"math/rand"
 	"time"
 
 	"log/slog"
@@ -28,7 +27,7 @@ func (o ThresholdSamplingOption) NewMiddleware() slogmulti.Middleware {
 		panic("unexpected Rate: must be between 0.0 and 1.0")
 	}
 
-	rand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	rand := newLockedRNG()
 	counters := newCounters()
 
 	return slogmulti.NewInlineMiddleware(

--- a/middleware_uniform.go
+++ b/middleware_uniform.go
@@ -2,8 +2,6 @@ package slogsampling
 
 import (
 	"context"
-	"math/rand"
-	"time"
 
 	"log/slog"
 
@@ -25,7 +23,7 @@ func (o UniformSamplingOption) NewMiddleware() slogmulti.Middleware {
 		panic("unexpected Rate: must be between 0.0 and 1.0")
 	}
 
-	rand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	rand := newLockedRNG()
 
 	return slogmulti.NewInlineMiddleware(
 		func(ctx context.Context, level slog.Level, next func(context.Context, slog.Level) bool) bool {

--- a/middleware_uniform_test.go
+++ b/middleware_uniform_test.go
@@ -1,0 +1,40 @@
+package slogsampling
+
+import (
+	"bytes"
+	"log/slog"
+	"sync"
+	"testing"
+
+	slogmulti "github.com/samber/slog-multi"
+)
+
+// This test previously failed with the race detector
+func TestUniformRace(t *testing.T) {
+	const numGoroutines = 100
+
+	buf := &bytes.Buffer{}
+	textLogHandler := slog.NewTextHandler(buf, nil)
+	sampleMiddleware := UniformSamplingOption{Rate: 0.2}.NewMiddleware()
+	sampledLogger := slog.New(slogmulti.Pipe(sampleMiddleware).Handler(textLogHandler))
+
+	wg := &sync.WaitGroup{}
+	wg.Add(numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
+		goroutineIndex := i
+		go func() {
+			defer wg.Done()
+			sampledLogger.Info("mesage from goroutine", "goroutineIndex", goroutineIndex)
+		}()
+	}
+	wg.Wait()
+
+	// numLines should be in exclusive range (0, numGoroutines)
+	// this is probabilistic so it might fail but is pretty unlikely
+	numLines := bytes.Count(buf.Bytes(), []byte("\n"))
+	if !(0 < numLines && numLines < numGoroutines) {
+		t.Errorf("numLines=%d; should be in exclusive range (0, %d)", numLines, numGoroutines)
+		t.Error("raw output:")
+		t.Error(buf.String())
+	}
+}


### PR DESCRIPTION
The math/rand.Rand random number generator is not safe to use from multiple goroutines. This change adds a test that failed with the race detector enabled. It fixes the problem by replacing uses of math/rand with a wrapper that holds a mutex.

FWIW: I don't actually use this package. I was just investigating some log sampling implementations, and searched for "slog sampling", and wanted to verify that `slog` itself doesn't have any internal mutexes or anything that would make this implementation thread safe. It does not appear that it does, so the mutex is necessary.

There is a higher performance variant: using sync.Pool to pool random number generators, but it is a bit more complicated, and probably doesn't actually matter unless something is really logging extremely frequently.